### PR TITLE
Fix socks buffer overflow

### DIFF
--- a/socks/socks.go
+++ b/socks/socks.go
@@ -2,6 +2,7 @@
 package socks
 
 import (
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -181,6 +182,9 @@ func Handshake(rw io.ReadWriter) (Addr, error) {
 		return nil, err
 	}
 	buf = buf[:n]
+	if len(buf) < 2 {
+		return nil, errors.New("Missing CMD")
+	}
 
 	if buf[1] != CmdConnect {
 		return nil, ErrCommandNotSupported


### PR DESCRIPTION
If you send empty lines to the TCP local socks instance, it crashes with an index out of range.
This change prevents the local socks instance from crashing.

To reproduce the crash, start the client:
```
./go-shadowsocks2 -c ss://AEAD_CHACHA20_POLY1305:Secret@:8488 -verbose  -socks :1080
```

Start nc:
```
nc localhost 1080
```

Press [Enter] a few times. The client will crash with `panic: runtime error: index out of range`
