### PR TITLE
Fix AEAD stream writer to write a big chunk buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fresh implementation of Shadowsocks in Go.
 
-GoDoc at https://godoc.org/github.com/riobard/go-shadowsocks2/
+GoDoc at https://godoc.org/github.com/Dreamacro/go-shadowsocks2/
 
 
 ## Features
@@ -15,12 +15,12 @@ GoDoc at https://godoc.org/github.com/riobard/go-shadowsocks2/
 
 ## Install
 
-Pre-built binaries are available from https://github.com/riobard/go-shadowsocks2/releases
+Pre-built binaries are available from https://github.com/Dreamacro/go-shadowsocks2/releases
 
 You can also build from source:
 
 ```sh
-go get -u -v github.com/riobard/go-shadowsocks2
+go get -u -v github.com/Dreamacro/go-shadowsocks2
 ```
 
 Requires Go >= 1.10.

--- a/core/cipher.go
+++ b/core/cipher.go
@@ -43,12 +43,14 @@ var streamList = map[string]struct {
 	KeySize int
 	New     func(key []byte) (shadowstream.Cipher, error)
 }{
+	"RC4-MD5":       {16, shadowstream.RC4MD5},
 	"AES-128-CTR":   {16, shadowstream.AESCTR},
 	"AES-192-CTR":   {24, shadowstream.AESCTR},
 	"AES-256-CTR":   {32, shadowstream.AESCTR},
 	"AES-128-CFB":   {16, shadowstream.AESCFB},
 	"AES-192-CFB":   {24, shadowstream.AESCFB},
 	"AES-256-CFB":   {32, shadowstream.AESCFB},
+	"CHACHA20":      {32, shadowstream.ChaCha20},
 	"CHACHA20-IETF": {32, shadowstream.Chacha20IETF},
 	"XCHACHA20":     {32, shadowstream.Xchacha20},
 }

--- a/core/cipher.go
+++ b/core/cipher.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/riobard/go-shadowsocks2/shadowaead"
-	"github.com/riobard/go-shadowsocks2/shadowstream"
+	"github.com/Dreamacro/go-shadowsocks2/shadowaead"
+	"github.com/Dreamacro/go-shadowsocks2/shadowstream"
 )
 
 type Cipher interface {

--- a/dialer.go
+++ b/dialer.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"net"
 
-	"github.com/riobard/go-shadowsocks2/core"
-	"github.com/riobard/go-shadowsocks2/socks"
-	"github.com/riobard/go-shadowsocks2/speeddial"
+	"github.com/Dreamacro/go-shadowsocks2/core"
+	"github.com/Dreamacro/go-shadowsocks2/socks"
+	"github.com/Dreamacro/go-shadowsocks2/speeddial"
 )
 
 type Dialer interface {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/riobard/go-shadowsocks2/core"
+	"github.com/Dreamacro/go-shadowsocks2/core"
 )
 
 var config struct {

--- a/shadowaead/stream.go
+++ b/shadowaead/stream.go
@@ -41,7 +41,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		buf[0], buf[1] = byte(nr>>8), byte(nr) // big-endian payload size
 		w.Seal(buf[:0], nonce, buf[:2], nil)
 		increment(nonce)
-		w.Seal(buf[:off], nonce, p[:nr], nil)
+		w.Seal(buf[:off], nonce, p[n:n+nr], nil)
 		increment(nonce)
 		_, err = w.Writer.Write(buf)
 	}

--- a/tcp.go
+++ b/tcp.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/riobard/go-shadowsocks2/socks"
+	"github.com/Dreamacro/go-shadowsocks2/socks"
 )
 
 func tcpKeepAlive(c net.Conn) {

--- a/tcp_darwin.go
+++ b/tcp_darwin.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/riobard/go-shadowsocks2/socks"
+	"github.com/Dreamacro/go-shadowsocks2/socks"
 )
 
 func redirLocal(addr string, d Dialer)  { tcpLocal(addr, d, pfNatLookup) }

--- a/tcp_linux.go
+++ b/tcp_linux.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/riobard/go-shadowsocks2/socks"
+	"github.com/Dreamacro/go-shadowsocks2/socks"
 )
 
 const (

--- a/udp.go
+++ b/udp.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/riobard/go-shadowsocks2/socks"
+	"github.com/Dreamacro/go-shadowsocks2/socks"
 )
 
 const udpBufSize = 64 * 1024


### PR DESCRIPTION
# Problem

I used `riobard/go-shadowsocks2` as an ss-client in my project and I wrapper a `net.Conn` after `StreamConn` without `WriteTo` and `ReadFrom`. 

Then I use `io.Copy` with two TCP connection. In AEAD cipher, I found out that the connection closes when to upload some images. The `Writer` is not written correctly when writing a big buffer.

# Question

When I discovered this bug, I assumed that `shadowsocks/go-shadowsocks2` had the same bug. But when I went to check, I found a big gap between the two implementations. So the two repositories are completely forked?


