### PR TITLE
Fix AEAD stream writer to write a big chunk buffer

### DIFF
--- a/shadowaead/stream.go
+++ b/shadowaead/stream.go
@@ -41,7 +41,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		buf[0], buf[1] = byte(nr>>8), byte(nr) // big-endian payload size
 		w.Seal(buf[:0], nonce, buf[:2], nil)
 		increment(nonce)
-		w.Seal(buf[:off], nonce, p[:nr], nil)
+		w.Seal(buf[:off], nonce, p[n:n+nr], nil)
 		increment(nonce)
 		_, err = w.Writer.Write(buf)
 	}


### PR DESCRIPTION
# Problem

I used `riobard/go-shadowsocks2` as an ss-client in my project and I wrapper a `net.Conn` after `StreamConn` without `WriteTo` and `ReadFrom`. 

Then I use `io.Copy` with two TCP connection. In AEAD cipher, I found out that the connection closes when to upload some images. The `Writer` is not written correctly when writing a big buffer.

# Question

When I discovered this bug, I assumed that `shadowsocks/go-shadowsocks2` had the same bug. But when I went to check, I found a big gap between the two implementations. So the two repositories are completely forked?
